### PR TITLE
Add basic Express backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+

--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
     "react-dom": "^19.1.0",
     "react-icons": "^5.5.0",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "express": "^4.19.2"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start:server": "node server/index.js"
   },
   "eslintConfig": {
     "extends": [

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,28 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+app.use(bodyParser.json());
+
+let tasks = [
+  { id: '#IEU-30', title: 'Review design documents', status: 'To Do', dueDate: '2025-07-03' },
+  { id: '#ASS-19', title: 'Code user authentication', status: 'Doing', dueDate: '2025-07-05' },
+  { id: '#ASS-18', title: 'Write unit tests', status: 'Incomplete', dueDate: '2025-07-08' },
+  { id: '#DMA-6', title: 'Update dashboard UI', status: 'Doing', dueDate: '2025-07-10' }
+];
+
+app.get('/api/tasks', (req, res) => {
+  res.json(tasks);
+});
+
+app.post('/api/tasks', (req, res) => {
+  const task = req.body;
+  tasks.push(task);
+  res.status(201).json(task);
+});
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add express to dependencies
- add start:server script
- implement simple tasks API in server/index.js
- ignore node_modules and env files

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468bcc4b7883318989152e55d68ca2